### PR TITLE
feat(command)/sync

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ import os
 
 import discord
 from discord.ext import commands
-from discord.ext.commands import Greedy, Context  # or a subclass of yours
+from discord.ext.commands import Greedy, Context
 from dotenv import load_dotenv
 
 load_dotenv()
@@ -28,7 +28,7 @@ async def on_ready():
 
 @bot.command()
 @commands.guild_only()
-@commands.is_owner()
+@commands.has_permissions(administrator=True)
 async def sync(
         ctx: Context, guilds: Greedy[discord.Object], botName):
     if not guilds and botName == BOT_NAME:

--- a/main.py
+++ b/main.py
@@ -2,10 +2,12 @@ import os
 
 import discord
 from discord.ext import commands
+from discord.ext.commands import Greedy, Context  # or a subclass of yours
 from dotenv import load_dotenv
 
 load_dotenv()
-TOKEN = os.getenv('DISCORD_TOKEN')
+TOKEN = os.getenv('DISCORD_BOT_TOKEN')
+BOT_NAME = os.getenv('DISCORD_BOT_NAME')
 
 intents = discord.Intents.all()
 bot = commands.Bot(command_prefix='!', intents=intents)
@@ -18,6 +20,25 @@ async def setup_hook():
             await bot.load_extension(f'cogs.{filename[:-3]}')
             print(f'{filename} has loaded!')
 
+
+@bot.event
+async def on_ready():
     print(f'{bot.user} has connected to Discord!')
+
+
+@bot.command()
+@commands.guild_only()
+@commands.is_owner()
+async def sync(
+        ctx: Context, guilds: Greedy[discord.Object], botName):
+    if not guilds and botName == BOT_NAME:
+        print("Syncing command(s)...")
+        synced = await bot.tree.sync()
+        await ctx.send(
+            f'Synced {len(synced)} command(s) globally!'
+        )
+        return
+
+    await ctx.send(f"Error: tree was not synced.")
 
 bot.run(TOKEN)


### PR DESCRIPTION
- Add an admin-only sync command, usable using `!sync`, which syncs the command tree to Discord to prevent ratelimiting and unecessary re-syncing