### PR TITLE
feat(command)/WIT-43-upcoming-events

### DIFF
--- a/api.py
+++ b/api.py
@@ -21,3 +21,14 @@ def getRandomMarketingPost(category):
             posts.append(post)
 
     return random.choice(posts)
+
+
+def getNextUpcomingEvent():
+    upcomingEvents = client.entries(
+        {'content_type': 'upcomingEvents', 'limit': 1, 'order': 'fields.index'})
+    return upcomingEvents[0]
+
+
+def getUpcomingEvents():
+    return client.entries(
+        {'content_type': 'upcomingEvents', 'order': 'fields.index'})

--- a/api.py
+++ b/api.py
@@ -32,3 +32,9 @@ def getNextUpcomingEvent():
 def getUpcomingEvents():
     return client.entries(
         {'content_type': 'upcomingEvents', 'order': 'fields.index'})
+
+
+def getMostRecentEvent():
+    pastEvents = client.entries(
+        {'content_type': 'pastEvents', 'limit': 1, 'order': '-fields.index'})
+    return pastEvents[0]

--- a/api.py
+++ b/api.py
@@ -20,11 +20,4 @@ def getRandomMarketingPost(category):
         if post.fields().get('img') != None:
             posts.append(post)
 
-    post = random.choice(posts)
-    postLabel = post.fields().get('label').replace(' ', '-') + '.png'
-    postLink = 'https:' + post.fields().get('img').url()
-
-    return {
-        'label': postLabel,
-        'link': postLink,
-    }
+    return random.choice(posts)

--- a/cogs/sendRandomPost.py
+++ b/cogs/sendRandomPost.py
@@ -26,13 +26,17 @@ class sendRandomPostCog(commands.Cog):
 
 
 async def sendPost(int: discord.Interaction, randomPost):
+    randomPostFields = randomPost.fields()
+    label = randomPostFields.get('label').replace(' ', '-') + '.png'
+    link = 'https:' + randomPostFields.get('img').url()
+
     async with aiohttp.ClientSession() as session:
         await int.response.defer()
-        async with session.get(randomPost.get('link')) as resp:
+        async with session.get(link) as resp:
             if resp.status != 200:
                 return await int.followup.send('Could not download file...')
             data = io.BytesIO(await resp.read())
-            await int.followup.send(file=discord.File(data, randomPost.get('label')))
+            await int.followup.send(file=discord.File(data, label))
 
 
 async def setup(bot: commands.Bot):

--- a/cogs/upcomingEvents.py
+++ b/cogs/upcomingEvents.py
@@ -4,6 +4,8 @@ from discord.ext import commands
 
 from api import getNextUpcomingEvent, getUpcomingEvents, getMostRecentEvent
 
+EVENT_RECAPS_LINK = 'https://unswwit.com/events/event-recaps/'
+
 
 class upcomingEventsCog(commands.Cog):
 
@@ -33,7 +35,7 @@ class upcomingEventsCog(commands.Cog):
 
 async def noEventsMessage(int: discord.Interaction):
     recentEventFields = getMostRecentEvent().fields()
-    return await int.response.send_message(f"Unfortunately WIT has no upcoming events for now! Keep an eye out on our socials for new events every term 🧡\n\n**Most Recent Event**\n{recentEventFields.get('title')}: https://unswwit.com/events/event-recaps/{recentEventFields.get('year')}/{recentEventFields.get('event_number')}")
+    return await int.response.send_message(f"Unfortunately WIT has no upcoming events for now! Keep an eye out on our socials for new events every term 🧡\n\n**Most Recent Event**\n{recentEventFields.get('title')}: {EVENT_RECAPS_LINK}{recentEventFields.get('year')}/{recentEventFields.get('event_number')}")
 
 
 async def setup(bot: commands.Bot):

--- a/cogs/upcomingEvents.py
+++ b/cogs/upcomingEvents.py
@@ -1,0 +1,32 @@
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+from api import getNextUpcomingEvent, getUpcomingEvents
+
+
+class upcomingEventsCog(commands.Cog):
+
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+
+    @app_commands.command(name="next-upcoming-event", description="See information about WIT's next upcoming event!")
+    async def nextUpcomingEvent(self, int: discord.Interaction):
+        nextEventFields = getNextUpcomingEvent().fields()
+        await int.response.send_message(f"**🧡 WIT's next event is *{nextEventFields.get('date')}*! 🧡**\n\n**Event Details:** {nextEventFields.get('title')}\n\n{nextEventFields.get('description')}\n**Event Link: **{nextEventFields.get('facebook_link')}")
+
+    @app_commands.command(name="all-upcoming-events", description="See an overview of all of WIT's upcoming events!")
+    async def upcomingEvents(self, int: discord.Interaction):
+        upcomingEvents = getUpcomingEvents()
+        if len(upcomingEvents) == 0:
+            return await int.response.send_message("\nUnfortunately WIT has no upcoming events for now! Keep an eye out on our socials for new events every term 🧡")
+
+        overview = "**🧡 WIT's Upcoming Events 🧡**"
+        for event in upcomingEvents:
+            eventFields = event.fields()
+            overview += f"\n\n*{eventFields.get('date')}*\n{eventFields.get('title')}: <{eventFields.get('facebook_link')}>"
+        await int.response.send_message(overview)
+
+
+async def setup(bot: commands.Bot):
+    await bot.add_cog(upcomingEventsCog(bot))

--- a/cogs/upcomingEvents.py
+++ b/cogs/upcomingEvents.py
@@ -2,7 +2,7 @@ import discord
 from discord import app_commands
 from discord.ext import commands
 
-from api import getNextUpcomingEvent, getUpcomingEvents
+from api import getNextUpcomingEvent, getUpcomingEvents, getMostRecentEvent
 
 
 class upcomingEventsCog(commands.Cog):
@@ -12,20 +12,28 @@ class upcomingEventsCog(commands.Cog):
 
     @app_commands.command(name="next-upcoming-event", description="See information about WIT's next upcoming event!")
     async def nextUpcomingEvent(self, int: discord.Interaction):
-        nextEventFields = getNextUpcomingEvent().fields()
-        await int.response.send_message(f"**🧡 WIT's next event is *{nextEventFields.get('date')}*! 🧡**\n\n**Event Details:** {nextEventFields.get('title')}\n\n{nextEventFields.get('description')}\n**Event Link: **{nextEventFields.get('facebook_link')}")
+        try:
+            nextEventFields = getNextUpcomingEvent().fields()
+            await int.response.send_message(f"**🧡 WIT's next event is *{nextEventFields.get('date')}*! 🧡**\n\n**Event Details:** {nextEventFields.get('title')}\n\n{nextEventFields.get('description')}\n**Event Link: **{nextEventFields.get('facebook_link')}")
+        except:
+            await noEventsMessage(int)
 
     @app_commands.command(name="all-upcoming-events", description="See an overview of all of WIT's upcoming events!")
     async def upcomingEvents(self, int: discord.Interaction):
         upcomingEvents = getUpcomingEvents()
         if len(upcomingEvents) == 0:
-            return await int.response.send_message("\nUnfortunately WIT has no upcoming events for now! Keep an eye out on our socials for new events every term 🧡")
+            return await noEventsMessage(int)
 
         overview = "**🧡 WIT's Upcoming Events 🧡**"
         for event in upcomingEvents:
             eventFields = event.fields()
             overview += f"\n\n*{eventFields.get('date')}*\n{eventFields.get('title')}: <{eventFields.get('facebook_link')}>"
         await int.response.send_message(overview)
+
+
+async def noEventsMessage(int: discord.Interaction):
+    recentEventFields = getMostRecentEvent().fields()
+    return await int.response.send_message(f"Unfortunately WIT has no upcoming events for now! Keep an eye out on our socials for new events every term 🧡\n\n**Most Recent Event**\n{recentEventFields.get('title')}: https://unswwit.com/events/event-recaps/{recentEventFields.get('year')}/{recentEventFields.get('event_number')}")
 
 
 async def setup(bot: commands.Bot):


### PR DESCRIPTION
Add the following slash commands:
- next-upcoming-event: posts a message displaying the datetime, title, description and facebook link of WIT's next upcoming event
- all-upcoming-events: posts a message displaying an overview of all of WITs upcoming events with the datetime, title and facebook link of each

If there are no upcoming events, posts a message with a link to the most recent WIT event recap.