### PR TITLE
chore(deps): revert charset-normalizer to v2.1.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ aiosignal==1.3.1
 async-timeout==4.0.2
 attrs==22.1.0
 black==23.1.0
-charset-normalizer==3.1.0
+charset-normalizer==2.1.1
 discord.py==2.1.0
 frozenlist==1.3.3
 idna==3.4


### PR DESCRIPTION
- revert charset-normalizer to v2.1.1 as aiohttp 3.8.3 depends on charset-normalizer<3.0 and >=2.0